### PR TITLE
Работа бота с командой !find_unanswered в личных сообщениях 

### DIFF
--- a/src/application/services/group_service.py
+++ b/src/application/services/group_service.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from typing import Any
 from models.domain import ChatMessage, ChatMessageSender
 from models.dto import RequestContext
+from models.enums import RoomType
 from dispatcher import Bot
-
-
-GROUP_TYPE = "p"
 
 
 class GroupService:
@@ -19,7 +17,7 @@ class GroupService:
         from_date: datetime = None,
         to_date: datetime = None,
     ) -> list[ChatMessage]:
-        groups = list(filter(lambda chan: chan["t"] == GROUP_TYPE, await bot.get_channels()))
+        groups = list(filter(lambda chan: chan["t"] == RoomType.GROUP, await bot.get_channels()))
         result: list[ChatMessage] = []
 
         for group in groups:

--- a/src/dispatcher/bot.py
+++ b/src/dispatcher/bot.py
@@ -6,7 +6,7 @@ from typing import Callable, Any, TYPE_CHECKING
 from functools import partial
 from http import HTTPStatus
 from pydantic import BaseModel
-from models.enums import EventType
+from models.enums import EventType, RoomType
 from handler import Handler, CallbackType
 import asyncio
 import uuid
@@ -69,18 +69,18 @@ class Bot[T: BaseModel]:
     async def get_channels(self) -> list[dict[str, str]]:
         """
         Возвращает список каналов, в которых состоит бот, в формате:
-        [{"_id": "channel_id", "t": "channel_type"}, "name": "channel_name", ...]
+        [{"_id": "channel_id", "t": "channel_type", "name": "channel_name"}, ...]
         """
-        channel_list = [
-        {
-            "_id": channel["_id"],
-            "t": channel["t"],
-            "name": "direct" if channel["t"] == "d" else channel["name"]
-        }
+        channels: list[dict[str, str]] = [
+            {
+                "_id": channel["_id"],
+                "t": channel["t"],
+                "name": "direct" if channel["t"] == RoomType.DIRECT else channel["name"]
+            }
             for channel in await self.async_client.get_channels_raw()
         ]
 
-        return channel_list
+        return channels
 
     # TODO: тут тоже надо будет поддержать oldest и latest (думаю надо будет уже str передавать, но мб и datetime)
     def get_group_history(self, group_id: str) -> dict[str, Any]:

--- a/src/dispatcher/bot.py
+++ b/src/dispatcher/bot.py
@@ -69,10 +69,14 @@ class Bot[T: BaseModel]:
     async def get_channels(self) -> list[dict[str, str]]:
         """
         Возвращает список каналов, в которых состоит бот, в формате:
-        [{"_id": "channel_id", "name": "channel_name", "t": "channel_type"}, ...]
+        [{"_id": "channel_id", "t": "channel_type"}, "name": "channel_name", ...]
         """
         channel_list = [
-            {"_id": channel["_id"], "name": channel["name"], "t": channel["t"]}
+        {
+            "_id": channel["_id"],
+            "t": channel["t"],
+            "name": "direct" if channel["t"] == "d" else channel["name"]
+        }
             for channel in await self.async_client.get_channels_raw()
         ]
 

--- a/src/models/enums/__init__.py
+++ b/src/models/enums/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
 from models.enums.command import Command
 from models.enums.event_type import EventType
+from models.enums.room_type import RoomType

--- a/src/models/enums/room_type.py
+++ b/src/models/enums/room_type.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class RoomType(str, Enum):
+    GROUP = "p"
+    DIRECT = "d"


### PR DESCRIPTION
Причина ошибки: бот получил команду в личных сообщениях.

Описание ошибки: у чатов ЛС нет поля `"name"`, поэтому при вызове `bot.get_channels()` и попытке добавить чат ЛС в `channel_list` возникала ошибка `KeyError: 'name'`.

Описание изменений:

- чаты ЛС добавляются в `channel_list` с именем по умолчанию `"direct"`
- предыдущий пункт никак не сказывается на работе команды `!find_unanswered`: бот ищет неотвеченные сообщения только в закрытых  группах и выдаёт результат там, где получил команду