### PR TITLE
Исправление пропажи сообщений при вызове !find_unanswered

### DIFF
--- a/src/dispatcher/bot.py
+++ b/src/dispatcher/bot.py
@@ -80,7 +80,7 @@ class Bot[T: BaseModel]:
 
     # TODO: тут тоже надо будет поддержать oldest и latest (думаю надо будет уже str передавать, но мб и datetime)
     def get_group_history(self, group_id: str) -> dict[str, Any]:
-        response = self.sync_client.groups_history(group_id, inclusive=True, count=10000000)
+        response = self.sync_client.groups_history(group_id, inclusive=True, count=0, offset=0)
         if response.status_code != HTTPStatus.OK:
             return {}
 


### PR DESCRIPTION
Необходимо применить следующие настройки `Administration > Workspace > Settings > General > REST API`:
![image](https://github.com/user-attachments/assets/1c154686-7807-44c9-af15-3ab049368055)

- `Default Count` - значение по умолчанию для результатов получения истории, если параметр `count` не указан
- `Max Record Amount` - максимальное ограничение для параметра `count`. Если указано большее значение, то будет применено это ограничение
- `Allow Getting Everything` - параметр определяет, разрешено ли передавать **значение 0 в качестве параметра `count` для получения всех записей**

Изменён вызов `groups_history(group_id, inclusive=True, count=0, offset=0)`:
`count` - количество возвращаемых элементов (0 для получения всех записей)
`offset` - количество элементов, которые необходимо «пропустить»