### PR TITLE
Игнор сообщений с реакцией ⚙️ при работе !find_unanswered

### DIFF
--- a/src/application/services/group_service.py
+++ b/src/application/services/group_service.py
@@ -7,9 +7,10 @@ from dispatcher import Bot
 
 
 class GroupService:
-    def __init__(self, command_prefix, service_reactions):
+    def __init__(self, command_prefix, service_reactions, priviliged_roles):
         self._command_prefix = command_prefix
         self._service_reactions = service_reactions
+        self._priviliged_roles = priviliged_roles
 
     async def get_unanswered_messages(
         self,
@@ -45,8 +46,15 @@ class GroupService:
                 if sender_id == bot.id:
                     continue
 
-                if "reactions" in message and self._service_reactions & set(message["reactions"].keys()):
-                    continue
+                if "reactions" in message:
+                    reactions = self._service_reactions & set(message["reactions"].keys())
+                                
+                    if any(
+                        bool(self._priviliged_roles & set(bot.get_roles(username=username)))
+                        for reaction in reactions
+                        for username in message["reactions"][reaction]["usernames"]
+                        ):
+                        continue
 
                 if "tmid" in message:
                     answered.add(message["tmid"])

--- a/src/application/services/group_service.py
+++ b/src/application/services/group_service.py
@@ -7,8 +7,9 @@ from dispatcher import Bot
 
 
 class GroupService:
-    def __init__(self, command_prefix):
+    def __init__(self, command_prefix, service_reactions):
         self._command_prefix = command_prefix
+        self._service_reactions = service_reactions
 
     async def get_unanswered_messages(
         self,
@@ -42,6 +43,9 @@ class GroupService:
                 '''
 
                 if sender_id == bot.id:
+                    continue
+
+                if "reactions" in message and self._service_reactions & set(message["reactions"].keys()):
                     continue
 
                 if "tmid" in message:

--- a/src/config.py
+++ b/src/config.py
@@ -10,6 +10,7 @@ class Config:
     rocket_chat_url: str = field(default=os.getenv("ROCKET_CHAT_URL"))
     mongo_url_for_app: str = field(default=os.getenv("MONGO_URL_FOR_APP"))
     command_prefix: str = "!"
+    service_reactions: frozenset[str] = frozenset((":gear:",))
     user_server_url: str = field(default=os.getenv("ROCKET_CHAT_URL"))
     priviliged_roles: frozenset[str] = field(default=frozenset(os.getenv("PRIVILIGED_ROLES").replace(" ", "").split(",")))
 

--- a/src/main.py
+++ b/src/main.py
@@ -23,7 +23,7 @@ def register_handlers(bot: Bot, cfg: Config) -> None:
                          StatsArgs, 
                          filters=[CommandFilter(Command.STATS), RoleFilter(cfg.priviliged_roles)])
 
-    group_service = GroupService(cfg.command_prefix, cfg.service_reactions)
+    group_service = GroupService(cfg.command_prefix, cfg.service_reactions, cfg.priviliged_roles)
     find_unanswered_handler = FindUnansweredHandler(cfg.user_server_url, group_service)
 
     bot.register_handler(find_unanswered_handler.handle,

--- a/src/main.py
+++ b/src/main.py
@@ -23,7 +23,7 @@ def register_handlers(bot: Bot, cfg: Config) -> None:
                          StatsArgs, 
                          filters=[CommandFilter(Command.STATS), RoleFilter(cfg.priviliged_roles)])
 
-    group_service = GroupService(cfg.command_prefix)
+    group_service = GroupService(cfg.command_prefix, cfg.service_reactions)
     find_unanswered_handler = FindUnansweredHandler(cfg.user_server_url, group_service)
 
     bot.register_handler(find_unanswered_handler.handle,


### PR DESCRIPTION
- В `src/config.py` добавлено множество служебных реакций
- Служебные реакции и привилегированные роли подаются в конструктор `GroupService`
- Сообщения со служебными реакциями от привилегированных юзеров попадают в игнор при поиске неотвеченных сообщений
- В игнор попадают сообщения и в самом чате, и в треде